### PR TITLE
UNREAL Reward Prediction

### DIFF
--- a/experiments/a2c.py
+++ b/experiments/a2c.py
@@ -109,8 +109,7 @@ demon_weights = torch.tensor([1.], device=device)
 
 
 horde = Horde(
-    control_demon=control_demon,
-    prediction_demons=prediction_demons,
+    demons=[control_demon],
     aggregation_fn=lambda losses: demon_weights.dot(losses),
     device=device
 )

--- a/experiments/dqn.py
+++ b/experiments/dqn.py
@@ -1,20 +1,17 @@
 from functools import reduce, partial
 
 import torch
-from gym_minigrid.envs import DoorKeyEnv, MultiRoomEnv
-from gym_minigrid.wrappers import ImgObsWrapper, FullyObsWrapper
-from pandemonium.utilities.schedules import ConstantSchedule, LinearSchedule
-
+from gym_minigrid.envs import DoorKeyEnv
+from gym_minigrid.wrappers import ImgObsWrapper
 from pandemonium import Agent, GVF, Horde
 from pandemonium.continuations import ConstantContinuation
 from pandemonium.cumulants import Fitness
 from pandemonium.demons.control import DQN
-from pandemonium.envs import EmptyEnv, FourRooms
-from pandemonium.envs.minigrid.wrappers import OneHotObsWrapper
 from pandemonium.envs.wrappers import Torch
 from pandemonium.experience import PER, ER
-from pandemonium.networks.bodies import ConvBody, Identity
+from pandemonium.networks.bodies import ConvBody
 from pandemonium.policies.discrete import Egreedy, SoftmaxPolicy
+from pandemonium.utilities.schedules import ConstantSchedule, LinearSchedule
 
 # device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 device = torch.device('cpu')
@@ -106,9 +103,7 @@ replay = PER(
     epsilon=1e-6
 )
 
-replay = ER(REPLAY_SIZE, BATCH_SIZE)
-
-prediction_demons = list()
+# replay = ER(REPLAY_SIZE, BATCH_SIZE)
 
 control_demon = DQN(
     gvf=gvf,
@@ -129,8 +124,7 @@ demon_weights = torch.tensor([1.], device=device)
 
 
 horde = Horde(
-    control_demon=control_demon,
-    prediction_demons=prediction_demons,
+    demons=[control_demon],
     aggregation_fn=lambda losses: demon_weights.dot(losses),
     device=device
 )

--- a/experiments/loop.py
+++ b/experiments/loop.py
@@ -7,8 +7,8 @@ import tensorboardX
 import torch
 from experiments import EXPERIMENT_DIR, RLogger
 # from experiments.option_critic import *
-# from experiments.unreal import *
-from experiments.a2c import *
+from experiments.unreal import *
+# from experiments.a2c import *
 # from experiments.dqn import *
 from pandemonium.experience import Trajectory
 

--- a/experiments/option_critic.py
+++ b/experiments/option_critic.py
@@ -95,7 +95,6 @@ policy = EgreedyOverOptions(
 #  initiating for some other policy
 
 BATCH_SIZE = 32
-prediction_demons = list()
 
 control_demon = OC(
     gvf=gvf,
@@ -111,8 +110,7 @@ demon_weights = torch.tensor([1.], device=device)
 
 
 horde = Horde(
-    control_demon=control_demon,
-    prediction_demons=prediction_demons,
+    demons=[control_demon]
     aggregation_fn=lambda losses: demon_weights.dot(losses)
 )
 AGENT = Agent(feature_extractor=feature_extractor, horde=horde)

--- a/experiments/unreal.py
+++ b/experiments/unreal.py
@@ -125,8 +125,7 @@ demon_weights = torch.tensor([1, 1], dtype=torch.float, device=device)
 # ------------------------------------------------------------------------------
 
 horde = Horde(
-    control_demon=control_demon,
-    prediction_demons=[pc],
+    demons=[control_demon, rp, vr, pc],
     aggregation_fn=lambda losses: demon_weights.dot(losses),
     device=device,
 )

--- a/pandemonium/demons/control.py
+++ b/pandemonium/demons/control.py
@@ -53,6 +53,9 @@ class DQN(DeepOfflineTDControl, TDn):
     def q_target(self, trajectory: Trajectory):
         q = self.predict_q(trajectory.x1, target=True)
         if self.double:
+            if isinstance(self, PixelControl):
+                # TODO: q[mask] returns flat obs
+                raise NotImplementedError
             v = q[torch_argmax_mask(self.aqf(trajectory.x1), 1)].unsqueeze(-1)
         else:
             v = q.max(1, keepdim=True)[0]

--- a/pandemonium/demons/control.py
+++ b/pandemonium/demons/control.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 
 import torch
-from torch import nn
-
 from pandemonium.demons import Loss, ParametricDemon
 from pandemonium.demons.offline_td import (DeepOfflineTD, TDn, TTD,
                                            OfflineTDPrediction)
@@ -12,6 +10,7 @@ from pandemonium.networks import Reshape
 from pandemonium.policies import Policy, HierarchicalPolicy, DiffPolicy
 from pandemonium.policies.utils import torch_argmax_mask
 from pandemonium.utilities.utilities import get_all_classes
+from torch import nn
 
 
 class DeepOfflineTDControl(DeepOfflineTD, OfflineTDControl):
@@ -186,19 +185,6 @@ class TDAC(AC, OfflineTDPrediction, TTD):
     def critic_loss(self, trajectory: Trajectory):
         loss, info = OfflineTDPrediction.delta(self, trajectory)
         return loss, info['td_error'], info
-
-
-class UNREAL(TDAC, TDn):
-    """ A version of AC that stores experience in the replay buffer """
-
-    def __init__(self, feature, replay_buffer: ER, **kwargs):
-        avf = nn.Linear(feature.feature_dim, 1)
-        super().__init__(avf=avf, feature=feature, **kwargs)
-        self.replay_buffer = replay_buffer
-
-    def learn(self, transitions: Transitions) -> Loss:
-        # self.replay_buffer.feed_batch(transitions)
-        return super().learn(transitions)
 
 
 class OC(AC, DQN):

--- a/pandemonium/envs/dm_lab/dm_env.py
+++ b/pandemonium/envs/dm_lab/dm_env.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple
 
-# import deepmind_lab
+import deepmind_lab
 import gym
 import numpy as np
 from gym.spaces import Box
@@ -34,7 +34,7 @@ class DeepmindLabEnv(gym.Env):
 
     def __init__(self, level: str, colors: str = 'RGB_INTERLEAVED',
                  width: int = 84, height: int = 84, fps: int = 60,
-                 display_size=(600, 400),
+                 display_size=(600, 400), render: bool = False,
                  **kwargs):
         super().__init__(**kwargs)
 
@@ -57,7 +57,9 @@ class DeepmindLabEnv(gym.Env):
 
         self.last_obs = None
 
-        self.display = DeepmindLabDisplay(display_size, env=self)
+        self.display = None
+        if render:
+            self.display = DeepmindLabDisplay(display_size, env=self)
 
     def step(self, action: int, frame_skip: int = 4):
         reward = self.lab.step(self.actions[action], num_steps=frame_skip)

--- a/pandemonium/experience/buffers.py
+++ b/pandemonium/experience/buffers.py
@@ -10,7 +10,7 @@ from pandemonium.experience.segment_tree import SumSegmentTree, MinSegmentTree
 from pandemonium.utilities.schedules import Schedule, ConstantSchedule
 from torch.distributions import Categorical
 
-__all__ = ['ER', 'PER']
+__all__ = ['ER', 'PER', 'SegmentedER']
 
 
 class ER:

--- a/pandemonium/horde.py
+++ b/pandemonium/horde.py
@@ -2,8 +2,9 @@ import textwrap
 from typing import List, Callable
 
 import torch
-from pandemonium.demons import Demon
 from torch import nn
+
+from pandemonium.demons import Demon
 
 
 class Horde(torch.nn.Module):

--- a/pandemonium/horde.py
+++ b/pandemonium/horde.py
@@ -2,7 +2,7 @@ import textwrap
 from typing import List, Callable
 
 import torch
-from pandemonium.demons import ControlDemon, PredictionDemon
+from pandemonium.demons import Demon
 from torch import nn
 
 
@@ -22,14 +22,12 @@ class Horde(torch.nn.Module):
     """
 
     def __init__(self,
-                 control_demon: ControlDemon,
-                 prediction_demons: List[PredictionDemon],
+                 demons: List[Demon],
                  aggregation_fn: Callable[[torch.Tensor], torch.Tensor],
                  device: torch.device,
                  ):
         super().__init__()
-        demons = {str(demon): demon for demon in prediction_demons}
-        demons.update({str(control_demon): control_demon})
+        demons = {str(demon): demon for demon in demons}
         self.demons = nn.ModuleDict(demons)
 
         # Determines how the total loss is weighted across demons


### PR DESCRIPTION
Latest updates to the UNREAL architecture

Adds a skewed replay buffer for reward prediction task which seems to help immensely from the first sight, although longer and wider experiments required to confirm that. 
Also fixes the target calculation for the reward prediction to split the rewards based on the sign and not just (1, 0, -1).

Attaching tensorboard screenshot after running a few versions with and without reward prediction task. Notably, none of the version without reward prediction task were able to surpass ~1 reward per episode mark after 10000 episodes. Only 2 out of 4 versions of UNREAL were able to make steady progress though. This requires more investigation, running with more seeds and for longer time.

![unreal](https://user-images.githubusercontent.com/25875478/78391400-4925d280-75b4-11ea-8015-b85504c4674c.png)
